### PR TITLE
add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "nestable2",
+  "version": "0.0.1",
+  "homepage": "https://github.com/RamonSmit/Nestable",
+  "authors": [
+    "Ramon Smit <@Ram0nSm1t>",
+    "David Bushell <@dbushell>"
+  ],
+  "description": "Drag & drop hierarchical list with mouse and touch compatibility",
+  "main": ["jquery.nestable.js"],
+  "keywords": [
+    "jquery",
+    "tree",
+    "list",
+    "sortable",
+    "nestable",
+    "drag",
+    "drop"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "jquery": ">= 1.7.2"
+  }
+}  


### PR DESCRIPTION
Mentioned in https://github.com/RamonSmit/Nestable/issues/6
I'll leave it to you to register the lib w/ bower.
I renamed it temporarily to nestable2 (since nestable is already registered) but that name is probably too confusing/should be something better honestly.
