### PR TITLE
Support for dynamic restricting of children elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,51 @@ $('.dd').nestable({
     }
 });
 ```
+
+`onDragStart` callback provided as an option is fired when user starts to drag an element.
+```js
+$('.dd').nestable({
+    onDragStart: function(l,e){
+        // l is the main container
+        // e is the element that was moved
+    }
+});
+```
+
+This callback can be used to manipulate element which is being dragged as well as whole list.
+For example you can conditionally add `.dd-nochildren` to forbid dropping current element to
+some other elements for instance based on `data-type` of current element and other elements:
+ 
+ ```js
+ $('.dd').nestable({
+     onDragStart: function (l, e) {
+         // get type of dragged element
+         var type = $(e).data('type');
+         
+         // based on type of dragged element add or remove no children class
+         switch (type) {
+             case 'type1':
+                 // element of type1 can be child of type2 and type3
+                 l.find("[data-type=type2]").removeClass('dd-nochildren');
+                 l.find("[data-type=type3]").removeClass('dd-nochildren');
+                 break;
+             case 'type2':
+                 // element of type2 cannot be child of type2 or type3
+                 l.find("[data-type=type2]").addClass('dd-nochildren');
+                 l.find("[data-type=type3]").addClass('dd-nochildren');
+                 break;
+             case 'type3':
+                 // element of type3 cannot be child of type2 but can be child of type3
+                 l.find("[data-type=type2]").addClass('dd-nochildren');
+                 l.find("[data-type=type3]").removeClass('dd-nochildren');
+                 break;
+             default:
+                 console.error("Invalid type");
+         }
+     }
+ });
+ ```
+
 ### Methods
 
 You can get a serialised object with all `data-*` attributes for each item.

--- a/jquery.nestable.css
+++ b/jquery.nestable.css
@@ -115,3 +115,7 @@
 .dd-dragel .dd-handle {
   box-shadow: 2px 4px 6px 0 rgba(0,0,0,.1);
 }
+
+.dd-nochildren > .dd-placeholder {
+  display: none;
+}

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -55,6 +55,7 @@
         fixed: false,
         includeContent: false,
         callback: function(l, e) {},
+        onDragStart: function(l, e) {},
         listRenderer: function(children, options) {
             var html = '<' + options.listNodeName + ' class="' + options.listClass + '">';
             html += children;
@@ -419,6 +420,8 @@
             var mouse = this.mouse,
                 target = $(e.target),
                 dragItem = target.closest(this.options.itemNodeName);
+
+            this.options.onDragStart.call(this, this.el, dragItem);
 
             this.placeEl.css('height', dragItem.height());
 


### PR DESCRIPTION
- add event fired when user starts to drag an element - `onDragStart` callback documented in README
- remove placeholder from elements which cannot have any children - hide `.dd-placeholder` from elements with `.dd-nochildren` inspired by [Steph Skardal](http://blog.endpoint.com/2014/07/customizing-nestable-jquery-plugin.html)
- add usage to README