### PR TITLE
Somehow document nodrag class

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Write your nested HTML lists like so:
                     <div class="dd-handle">Item 4</div>
                 </li>
                 <li class="dd-item" data-id="5" data-foo="bar">
-                    <div class="dd-handle">Item 5</div>
+                    <div class="dd-nodrag">Item 5</div>
                 </li>
             </ol>
         </li>


### PR DESCRIPTION
The `dd-nodrag` class is documented as a configuration, but there is no documentation, that you should **replace** `dd-handle` with `dd-nodrag`.

Either this is a bug, or it should be better documented. Since I can't open an issue, this way someone can find the correct usage if he searches for `nodrag`.