### PR TITLE
Fix error at onEndEvent for touche devices.

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -169,7 +169,7 @@
             var onEndEvent = function(e) {
                 if(list.dragEl) {
                     e.preventDefault();
-                    list.dragStop(hasTouch ? e.touches[0] : e);
+                    list.dragStop(hasTouch ? e.changedTouches[0] : e);
                 }
             };
 


### PR DESCRIPTION
At onEndEvent there is no elements at e.touches, so e.touches[0]  leads to an exception.
Using e.changedTouches[0] resolves the issue.