### PR TITLE
Add option to disable drag event

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $('.dd').nestable({
 });
 ```
 
-`onDragStart` callback provided as an option is fired when user starts to drag an element.
+`onDragStart` callback provided as an option is fired when user starts to drag an element. Returning `false` from this callback will disable the dragging.
 ```js
 $('.dd').nestable({
     onDragStart: function(l,e){
@@ -288,6 +288,10 @@ These advanced config options are also available:
 **Inspect the [Nestable Demo](http://ramonsmit.github.io/Nestable/) for guidance.**
 
 ## Change Log
+
+### 16th June 2017
+
+* [imliam] Added support to return `false` from the `onDragStart` event to disable the drag event
 
 ### 28th May 2017
 

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -604,7 +604,11 @@
             position.top = e.pageY;
             position.left = e.pageX;
 
-            this.options.onDragStart.call(this, this.el, dragItem, position);
+            var continueExecution = this.options.onDragStart.call(this, this.el, dragItem, position);
+
+            if (typeof continueExecution !== 'undefined' && continueExecution === false) {
+                return;
+            }
 
             this.placeEl.css('height', dragItem.height());
 


### PR DESCRIPTION
In the situation where you need to keep the nestable object for all its benefits (consistent styling, add/destroy/etc. methods, and so on) but for a read-only page, it can be useful to disable the dragging events from their visual effects and changing the order of the data.

This patch allows you to `return false;` from the onDragStart option when initialising the nestable object, disabling this from occuring.