### PR TITLE
Serialize get data-* from DOM, bypass data-* cache

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -452,7 +452,7 @@
                     var liData = {};
                     $(this).each(function() {
                         $.each(this.attributes, function() {
-                            if(this.specified && this.name.startsWith("data-")) {
+                            if (this.specified && this.name.startsWith("data-")) {
                                 liData[this.name.replace("data-", "")] = this.value;
                             }
                         });

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -448,8 +448,17 @@
                 var array = [],
                     items = level.children(list.options.itemNodeName);
                 items.each(function() {
+                    // Get data-* from DOM, bypass data-* cache
+                    var liData = {};
+                    $(this).each(function() {
+                        $.each(this.attributes, function() {
+                            if(this.specified && this.name.startsWith("data-")) {
+                                liData[this.name.replace("data-", "")] = this.value;
+                            }
+                        });
+                    });
                     var li = $(this),
-                        item = $.extend({}, li.data()),
+                        item = $.extend({}, liData),
                         sub = li.children(list.options.listNodeName);
 
                     if (list.options.includeContent) {


### PR DESCRIPTION
The jQuery .data() function caching the data-attributes. If we need to dynamically edit the data attribute, the value isn't updated in the output.

### Expected behavior
In this example the problem is fixed https://jsfiddle.net/4df99Lts/3/ (Nestable2 1.6.0-fixed)

### Actual behavior
In this example the problem https://jsfiddle.net/4df99Lts/1/ (Nestable2 1.6.0)

### Steps to reproduce the behavior
Touch "Configure" on ID: 5. Change value and save. In version https://jsfiddle.net/4df99Lts/3/ the problem is fixed, also, in the https://jsfiddle.net/4df99Lts/1/ no.

Best regards
