### PR TITLE
Fixed json build

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,7 @@ NOTE: serialized JSON has been expanded so that an optional "content" property c
 Or do it yourself the old-fashioned way:
 ```html
 <div class="dd" id="nestable3">
-    <ol class='dd-list dd3-list'>
-        <div id="dd-empty-placeholder"></div>
+    <ol class='dd-list dd3-list' id="dd-empty-placeholder">
     </ol>
 </div>
 


### PR DESCRIPTION
If you add the items into a "\<div>\</div>" tag, instead of adding them in an "\<ol>\</ol>" tag, the default functions like "*.nestable('serialize')" don't work.